### PR TITLE
Modified to allow multiple instances of same file type.

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -25,7 +25,7 @@ type Event struct {
 
 // subscriber is some host that wants to receive events
 type subscriber struct {
-	Host string
+	Name string
 	Send chan *Event
 }
 
@@ -49,13 +49,13 @@ func New() *Buffer {
 	}
 }
 
-func (b *Buffer) AddSubscriber(host string, ch chan *Event) error {
-	b.add <- &subscriber{host, ch}
+func (b *Buffer) AddSubscriber(name string, ch chan *Event) error {
+	b.add <- &subscriber{name, ch}
 	return nil
 }
 
-func (b *Buffer) DelSubscriber(host string) error {
-	b.del <- host
+func (b *Buffer) DelSubscriber(name string) error {
+	b.del <- name
 	return nil
 }
 
@@ -77,11 +77,11 @@ func (b *Buffer) Start() {
 		case e := <-b.send:
 			b.Publish(e)
 		case s := <-b.add:
-			if _, ok := b.subscribers[s.Host]; ok {
-				log.Printf("A subscriber is already registered for %s\n", s.Host)
+			if _, ok := b.subscribers[s.Name]; ok {
+				log.Printf("A subscriber is already registered for %s\n", s.Name)
 				continue
 			}
-			b.subscribers[s.Host] = s
+			b.subscribers[s.Name] = s
 		case h := <-b.del:
 			delete(b.subscribers, h)
 		case <-b.term:
@@ -91,6 +91,7 @@ func (b *Buffer) Start() {
 		}
 	}
 }
-func (b *Buffer) Stop() {
+func (b *Buffer) Stop() error {
 	b.term <- true
+	return nil
 }

--- a/examples/example.config.yml
+++ b/examples/example.config.yml
@@ -1,18 +1,24 @@
+---
 inputs:
-  filebeat:
-    host: :7200
-    ssl_key: filebeat.key
-    ssl_crt: filebeat.crt
+  - all_filebeat:
+      filebeat:
+        host: 0.0.0.0:5000
+        ssl_key: "/etc/filebeat/filebeat.key"
+        ssl_crt: "/etc/filebeat/filebeat.crt"
+
 outputs:
-  tcp:
-    host: :7201
-  websocket:
-     host: :7202
-  elasticsearch:
-    hosts:
-      - http://localhost:9200
-    index: "logstash"
-    index_type: "logzoom"
-    gzip_enabled: false
-    info_log_enabled: false
-    error_log_enabled: false
+  - tcp1:
+      tcp:
+        host: "127.0.0.1:6000"
+  - ws1:
+      websocket:
+        host: 0.0.0.0:7200
+  - es:
+      elasticsearch:
+        hosts:
+          - http://localhost:9200
+        index: "logstash"
+        index_type: "type1"
+        gzip_enabled: false
+        info_log_enabled: false
+        error_log_enabled: false

--- a/examples/example.elasticsearch-output.yml
+++ b/examples/example.elasticsearch-output.yml
@@ -1,17 +1,42 @@
 ---
 inputs:
-  redis:
-    db: 10
-    host: localhost
-    input_queue: elasticsearch
-    working_queue: es_working
-    port: 6379
+  - redis_type1:
+      redis:
+        db: 10
+        host: localhost
+        input_queue: type1_elasticsearch
+        port: 6379
+  - redis_type2:
+      redis:
+        db: 10
+        host: localhost
+        input_queue: type2_elasticsearch
+        port: 6379
+
 outputs:
-  elasticsearch:
-    hosts:
-      - http://localhost:9200
-    index: "logstash"
-    index_type: "logzoom"
-    gzip_enabled: false
-    info_log_enabled: true
-    error_log_enabled: true
+  - type1_es:
+      elasticsearch:
+        hosts:
+          - http://localhost:9200
+        index: "logstash"
+        index_type: "type1"
+        gzip_enabled: false
+        info_log_enabled: true
+        error_log_enabled: true
+  - type2_es:
+      elasticsearch:
+        hosts:
+          - http://localhost:9200
+        index: "logstash"
+        index_type: "type2"
+        gzip_enabled: false
+        info_log_enabled: true
+        error_log_enabled: true
+
+routes:
+  - route1:
+      input: redis_type1
+      output: type1_es
+  - route2:
+      input: redis_type2
+      output: type2_es

--- a/examples/example.filebeat-to-redis.yml
+++ b/examples/example.filebeat-to-redis.yml
@@ -1,12 +1,31 @@
 ---
 inputs:
-  filebeat:
-      host: 0.0.0.0:5000
-      ssl_crt: /etc/filebeat/filebeat.crt
-      ssl_key: /etc/filebeat/filebeat.key
+  - all_filebeat:
+      filebeat:
+        host: 0.0.0.0:5000
+        ssl_crt: /etc/filebeat/filebeat.crt
+        ssl_key: /etc/filebeat/filebeat.key
 outputs:
-  redis:
-      db: 10
-      host: localhost
-      copy_queues: ["elasticsearch", "s3"]
-      port: 6379
+  - type1_redis:
+      redis:
+        db: 10
+        host: localhost
+        copy_queues: ["log_type1_elasticsearch", "log_type1_s3"]
+        port: 6379
+  - type2_redis:
+      redis:
+        db: 10
+        host: localhost
+        copy_queues: ["log_type2_elasticsearch", "log_type2_s3"]
+        port: 6379
+routes:
+  - route1:
+      input: all_filebeat
+      rules:
+        log_type: "log_type1"
+      output: log_type1_redis
+  - route2:
+      input: all_filebeat
+      rules:
+        log_type: "log_type2"
+      output: log_type2_redis

--- a/examples/example.s3-output.yml
+++ b/examples/example.s3-output.yml
@@ -1,18 +1,44 @@
 ---
 inputs:
-  redis:
-    db: 10
-    host: localhost
-    input_queue: s3
-    working_queue: s3_1
-    port: 6379
+  - redis_type1:
+      redis:
+        db: 10
+        host: localhost
+        input_queue: type1_s3
+        port: 6379
+  - redis_type2:
+      redis:
+        db: 10
+        host: localhost
+        input_queue: type2_s3
+        port: 6379
+
 outputs:
-  s3:
-    aws_key_id: <YOUR KEY HERE>
-    aws_sec_key: <YOUR SECRET HERE>
-    aws_s3_bucket: your-s3-bucket
-    aws_s3_region: us-west-1
-    local_path: /tmp
-    s3_path: your-s3-path
-    time_slice_format: %Y-%m-%d/%H%M
-    aws_s3_output_key: %{path}/%{timeSlice}/%{hostname}_%{uuid}.gz
+  - s3_type1:
+      s3:
+        aws_key_id_loc: < Your AWS Key ID File Loc >
+        aws_sec_key_loc: < Your AWS Secret Access Key Loc >
+        aws_s3_bucket: < Your AWS Bucket >
+        aws_s3_region: < Your AWS Bucket Region >
+        local_path: "local-path-to-dump-temp-file"
+        s3_path: "path-in-bucket-to-put-the-file"
+        time_slice_format: "%Y-%m-%d/%H%M"
+        aws_s3_output_key: "%{path}/%{timeSlice}/%{hostname}_%{uuid}.gz"
+  - s3_type2:
+      s3:
+        aws_key_id_loc: < Your AWS Key ID File Loc >
+        aws_sec_key_loc: < Your AWS Secret Access Key Loc >
+        aws_s3_bucket: < Your AWS Bucket >
+        aws_s3_region: < Your AWS Bucket Region >
+        local_path: "local-path-to-dump-temp-file"
+        s3_path: "path-in-bucket-to-put-the-file"
+        time_slice_format: "%Y-%m-%d/%H%M"
+        aws_s3_output_key: "%{path}/%{timeSlice}/%{hostname}_%{uuid}.gz"
+
+routes:
+  - route1:
+      input: redis_type1
+      output: s3_type1
+  - route2:
+      input: redis_type2
+      output: s3_type2

--- a/input/filebeat/filebeat.go
+++ b/input/filebeat/filebeat.go
@@ -5,7 +5,5 @@ import (
 )
 
 func init() {
-	input.Register("filebeat", &LJServer{
-		term: make(chan bool, 1),
-	})
+	input.Register("filebeat", New)
 }

--- a/input/filebeat/lumberjack.go
+++ b/input/filebeat/lumberjack.go
@@ -17,9 +17,14 @@ type Config struct {
 }
 
 type LJServer struct {
+	name   string
 	Config *Config
 	r      input.Receiver
 	term   chan bool
+}
+
+func New() input.Input {
+        return &LJServer{term: make(chan bool, 1)}
 }
 
 // lumberConn handles an incoming connection from a lumberjack client
@@ -30,7 +35,7 @@ func lumberConn(c net.Conn, r input.Receiver) {
 	log.Printf("[%s] closing lumberjack connection", c.RemoteAddr().String())
 }
 
-func (lj *LJServer) Init(config yaml.MapSlice, r input.Receiver) error {
+func (lj *LJServer) Init(name string, config yaml.MapSlice, r input.Receiver) error {
 	var ljConfig *Config
 
 	// go-yaml doesn't have a great way to partially unmarshal YAML data
@@ -41,6 +46,7 @@ func (lj *LJServer) Init(config yaml.MapSlice, r input.Receiver) error {
 		return fmt.Errorf("Error parsing lumberjack config: %v", err)
 	}
 
+	lj.name = name
 	lj.Config = ljConfig
 	lj.r = r
 
@@ -62,6 +68,7 @@ func (lj *LJServer) Start() error {
 
 	ln := tls.NewListener(conn, &config)
 
+	log.Printf("[%s] Started Lumberjack Instance", lj.name)
 	for {
 		select {
 		case <-lj.term:

--- a/input/input.go
+++ b/input/input.go
@@ -12,27 +12,27 @@ type Receiver interface {
 }
 
 type Input interface {
-	Init(yaml.MapSlice, Receiver) error
+	Init(string, yaml.MapSlice, Receiver) error
 	Start() error
 	Stop() error
 }
 
 var (
-	inputs = make(map[string]Input)
+	inputs = make(map[string]func()Input)
 )
 
-func Register(name string, input Input) error {
+func Register(name string, constructor func()Input) error {
 	if _, ok := inputs[name]; ok {
 		return fmt.Errorf("Input %s already exists", name)
 	}
-	inputs[name] = input
+	inputs[name] = constructor
 	return nil
 }
 
 func Load(name string) (Input, error) {
-	input, ok := inputs[name]
+	constructor, ok := inputs[name]
 	if !ok {
-		return nil, fmt.Errorf("Input %s not found", name)
+		return nil, fmt.Errorf("Constructor %s not found", name)
 	}
-	return input, nil
+	return constructor(), nil
 }

--- a/output/output.go
+++ b/output/output.go
@@ -5,30 +5,31 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/packetzoom/logzoom/buffer"
+	"github.com/packetzoom/logzoom/route"
 )
 
 type Output interface {
-	Init(yaml.MapSlice, buffer.Sender) error
+	Init(string, yaml.MapSlice, buffer.Sender, route.Route) error
 	Start() error
 	Stop() error
 }
 
 var (
-	outputs = make(map[string]Output)
+	outputs = make(map[string]func()Output)
 )
 
-func Register(name string, output Output) error {
+func Register(name string, constructor func()Output) error {
 	if _, ok := outputs[name]; ok {
 		return fmt.Errorf("Output %s already exists", name)
 	}
-	outputs[name] = output
+	outputs[name] = constructor
 	return nil
 }
 
 func Load(name string) (Output, error) {
-	output, ok := outputs[name]
+	constructor, ok := outputs[name]
 	if !ok {
 		return nil, fmt.Errorf("Output %s not found", name)
 	}
-	return output, nil
+	return constructor(), nil
 }

--- a/route/route.go
+++ b/route/route.go
@@ -1,0 +1,7 @@
+package route
+
+type Route struct {
+	Input	string
+	Output	string
+	Fields	map[string]string
+}

--- a/server/config.go
+++ b/server/config.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Config struct {
-	Inputs  map[string]yaml.MapSlice `yaml:"inputs"`
-	Outputs map[string]yaml.MapSlice `yaml:"outputs"`
+	Inputs  []map[string]yaml.MapSlice `yaml:"inputs"`
+	Outputs []map[string]yaml.MapSlice `yaml:"outputs"`
+	Routes  []map[string]yaml.MapSlice `yaml:"routes"`
 }
 
 func LoadConfig(file string) (*Config, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -6,19 +6,21 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
-
+	"gopkg.in/yaml.v2"
 	"github.com/packetzoom/logzoom/buffer"
 	"github.com/packetzoom/logzoom/input"
 	"github.com/packetzoom/logzoom/output"
+	"github.com/packetzoom/logzoom/route"
 )
 
 type Server struct {
 	Config *Config
-	Buffer *buffer.Buffer
+	buffers map[string]*buffer.Buffer
 
-	mtx     sync.Mutex
-	inputs  map[string]input.Input
+	mtx	sync.Mutex
+	inputs	map[string]input.Input
 	outputs map[string]output.Output
+	routes	map[string]route.Route
 }
 
 func signalCatcher() chan os.Signal {
@@ -35,66 +37,116 @@ func New(configFile string) (*Server, error) {
 
 	return &Server{
 		Config:  config,
-		Buffer:  buffer.New(),
+		buffers: make(map[string]*buffer.Buffer),
 		inputs:  make(map[string]input.Input),
 		outputs: make(map[string]output.Output),
+		routes:  make(map[string]route.Route),
 	}, nil
 }
 
 func (s *Server) Start() {
 	log.Println("Starting server")
 
-	// Start buffer
-	log.Println("Starting buffer")
-	go s.Buffer.Start()
 
 	s.mtx.Lock()
 
+	// Start buffer
+	log.Println("Starting buffer")
+	// Init routes
+	for _, routeEntry := range s.Config.Routes {
+		for name, routeDetails := range routeEntry {
+			var input string
+			var output string
+			rules := make(map[string]string)
+			for _, item := range routeDetails {
+				if item.Key.(string) == "input" {
+					input = item.Value.(string)
+				}
+				if item.Key.(string) == "output" {
+					output = item.Value.(string)
+				}
+				if item.Key.(string) == "rules" {
+					for _, rule := range item.Value.(yaml.MapSlice) {
+						rules[rule.Key.(string)] = rule.Value.(string)
+					}
+				}
+			}
+			if (&input != nil && &output != nil) {
+				s.buffers[input] = buffer.New()
+				go s.buffers[input].Start()
+				route := route.Route{Input: input, Output: output, Fields: rules}
+				s.routes[name] = route
+			}
+		}
+	}
+
 	// Start inputs
-	for name, config := range s.Config.Inputs {
-		in, err := input.Load(name)
-		if err != nil {
-			log.Println(err.Error)
-			continue
-		}
-
-		if err := in.Init(config, s.Buffer); err != nil {
-			log.Fatalf("Failed to init %s input: %v", name, err)
-		}
-
-		go func(name string, in input.Input) {
-			log.Printf("Starting input %s", name)
-			if err := in.Start(); err != nil {
-				log.Fatalf("Error starting input %s: %v", name, err)
+	for _, inputEntry := range s.Config.Inputs {
+		for name, inputConfig := range inputEntry {
+			for i, item := range inputConfig {
+				if i > 0 {
+					panic("There are more than one configuration specified for an input entry.")
+				}
+				if i == 0 { //There should be only 1 input per entry
+					in, err := input.Load(item.Key.(string))
+					if err != nil {
+						log.Println(err.Error)
+						continue
+					}
+					err = in.Init(name, item.Value.(yaml.MapSlice), s.buffers[name]);
+					if err != nil {
+						log.Fatalf("Failed to init %s input: %v", item.Key, err)
+					}
+					go func(name string, in input.Input) {
+						if err := in.Start(); err != nil {
+							log.Fatalf("Error starting input %s: %v", item.Key, err)
+						}
+					} (name, in)
+					s.inputs[name] = in
+				}
 			}
-		}(name, in)
-
-		s.inputs[name] = in
+		}
 	}
-
 	// Start outputs
-	for name, config := range s.Config.Outputs {
-		out, err := output.Load(name)
-		if err != nil {
-			log.Println(err.Error)
-			continue
-		}
-
-		if err := out.Init(config, s.Buffer); err != nil {
-			log.Fatalf("Failed to init %s output: %v", name, err)
-			continue
-		}
-
-		go func(name string, out output.Output) {
-			log.Printf("Starting output %s", name)
-			if err := out.Start(); err != nil {
-				log.Fatalf("Error starting output %s: %v", name, err)
+	for _, outputEntry := range s.Config.Outputs {
+		for name, outputConfig := range outputEntry {
+			for i, item := range outputConfig {
+				if i > 0 {
+					panic("There are more than one configuration specified for an output entry.")
+				}
+				if i == 0 { //There should be only 1 output per entry
+					out, err := output.Load(item.Key.(string))
+					if err != nil {
+						log.Println(err.Error)
+						continue
+					}
+					init := false
+					for route_name, value := range s.routes {
+						if value.Output == name {
+							err = out.Init(name, item.Value.(yaml.MapSlice), s.buffers[value.Input], s.routes[route_name]);
+							if err != nil {
+								log.Fatalf("Failed to init %s input: %v", item.Key, err)
+							}
+							init = true
+							break
+						}
+					}
+					if init == false {
+						err = out.Init(name, item.Value.(yaml.MapSlice), nil, route.Route{Input: "", Output: "", Fields: make(map[string]string)});
+						if err != nil {
+							log.Fatalf("Failed to init %s output: %v", item.Key, err)
+						}
+					}
+					go func(name string, instance output.Output) {
+						if err := out.Start(); err != nil {
+							log.Fatalf("Error starting output %s: %v", item.Key, err)
+						}
+					} (name, out)
+					s.outputs[name] = out
+				}
 			}
-		}(name, out)
-
-		s.outputs[name] = out
+		}
 	}
-
 	s.mtx.Unlock()
 
 	// Wait for kill signal
@@ -128,6 +180,10 @@ func (s *Server) Stop() {
 
 	s.mtx.Unlock()
 
-	log.Println("Stopping buffer")
-	s.Buffer.Stop()
+	for name, buffer := range s.buffers {
+		log.Printf("Stopping buffer for input: %s", name)
+		if err := buffer.Stop(); err != nil {
+			log.Printf("Error stopping %s buffer: %v", name, err)
+		}
+	}
 }


### PR DESCRIPTION
Note: Configurations for AWS ID and Keys has changed. To use S3 outputs, do create files to store the values of the id and key and set the path of the file in the configurations. Refer to the examples of config file for the new configuration structure.
