### PR TITLE
added simple filter on field functionality

### DIFF
--- a/output/elasticsearch/elasticsearch.go
+++ b/output/elasticsearch/elasticsearch.go
@@ -110,7 +110,7 @@ func (i *Indexer) index(ev *buffer.Event) error {
 			return nil
 		}
 		strval, isstr := val.(string)
-		if !isstr || (isstr && value != strval) {
+		if !isstr || value != strval {
 			//early out if no match
 			return nil
 		}

--- a/output/elasticsearch/elasticsearch.go
+++ b/output/elasticsearch/elasticsearch.go
@@ -104,7 +104,13 @@ func (i *Indexer) flush() error {
 
 func (i *Indexer) index(ev *buffer.Event) error {
 	for key, value := range i.fields {
-		if (*ev.Fields)[key] == nil || ((*ev.Fields)[key] != nil && value != (*ev.Fields)[key].(string)) {
+		val, ok := (*ev.Fields)[key]
+		if !ok {
+			//early out if no match
+			return nil
+		}
+		strval, isstr := val.(string)
+		if !isstr || (isstr && value != strval) {
 			//early out if no match
 			return nil
 		}

--- a/output/redis/redis.go
+++ b/output/redis/redis.go
@@ -182,7 +182,7 @@ func (redisServer *RedisServer) Start() error {
 					break
 				}
 				strval, isstr := val.(string)
-				if !isstr || (isstr && value != strval) {
+				if !isstr || value != strval {
 					allowed = false
 					break
 				}

--- a/output/s3/s3.go
+++ b/output/s3/s3.go
@@ -290,7 +290,13 @@ func (s3Writer *S3Writer) Start() error {
 			var allowed bool
 			allowed = true
 			for key, value := range s3Writer.fields {
-				if (*ev.Fields)[key] == nil || ((*ev.Fields)[key] != nil && value != (*ev.Fields)[key].(string)) {
+				val, ok := (*ev.Fields)[key]
+				if !ok {
+					allowed = false
+					break
+				}
+				strval, isstr := val.(string)
+				if !isstr || (isstr && value != strval) {
 					allowed = false
 					break
 				}

--- a/output/s3/s3.go
+++ b/output/s3/s3.go
@@ -41,15 +41,16 @@ func uuid() string {
 }
 
 type Config struct {
-	AwsKeyIdLoc string `yaml:"aws_key_id_loc"`
+	AwsKeyIdLoc  string `yaml:"aws_key_id_loc"`
 	AwsSecKeyLoc string `yaml:"aws_sec_key_loc"`
-	AwsS3Bucket string `yaml:"aws_s3_bucket"`
-	AwsS3Region string `yaml:"aws_s3_region"`
+	AwsS3Bucket  string `yaml:"aws_s3_bucket"`
+	AwsS3Region  string `yaml:"aws_s3_region"`
 
-	LocalPath       string `yaml:"local_path"`
-	Path            string `yaml:"s3_path"`
-	TimeSliceFormat string `yaml:"time_slice_format"`
-	AwsS3OutputKey  string `yaml:"aws_s3_output_key"`
+	LocalPath       string  `yaml:"local_path"`
+	Path            string  `yaml:"s3_path"`
+	TimeSliceFormat string  `yaml:"time_slice_format"`
+	AwsS3OutputKey  string  `yaml:"aws_s3_output_key"`
+	IfHasField      *string `yaml:"if_has_field"`
 }
 
 type OutputFileInfo struct {
@@ -181,7 +182,7 @@ func init() {
 	output.Register("s3", New)
 }
 
-func New() (output.Output) {
+func New() output.Output {
 	return &S3Writer{term: make(chan bool, 1)}
 }
 
@@ -265,7 +266,7 @@ func (s3Writer *S3Writer) Init(name string, config yaml.MapSlice, sender buffer.
 }
 
 func (s3Writer *S3Writer) Start() error {
-	if (s3Writer.Sender == nil) {
+	if s3Writer.Sender == nil {
 		log.Printf("[%s] No route is specified for this output", s3Writer.name)
 		return nil
 	}
@@ -273,7 +274,7 @@ func (s3Writer *S3Writer) Start() error {
 	fileSaver := new(FileSaver)
 	fileSaver.Config = s3Writer.Config
 	fileSaver.RateCounter = ratecounter.NewRateCounter(1 * time.Second)
-
+	ifHasField := s3Writer.Config.IfHasField
 	id := "s3_output"
 	// Add the client as a subscriber
 	receiveChan := make(chan *buffer.Event, recvBuffer)
@@ -290,10 +291,18 @@ func (s3Writer *S3Writer) Start() error {
 		case ev := <-receiveChan:
 			var allowed bool
 			allowed = true
-			for key, value :=  range s3Writer.fields {
-				if ((*ev.Fields)[key] == nil || ((*ev.Fields)[key] != nil && value != (*ev.Fields)[key].(string))) {
+			//quick filter hack - rrichardson 2016/09
+			if ifHasField != nil {
+				if _, ok := (*ev.Fields)[*ifHasField]; !ok {
 					allowed = false
-					break
+				}
+			}
+			if allowed {
+				for key, value := range s3Writer.fields {
+					if (*ev.Fields)[key] == nil || ((*ev.Fields)[key] != nil && value != (*ev.Fields)[key].(string)) {
+						allowed = false
+						break
+					}
 				}
 			}
 			if allowed {

--- a/output/s3/s3.go
+++ b/output/s3/s3.go
@@ -296,7 +296,7 @@ func (s3Writer *S3Writer) Start() error {
 					break
 				}
 				strval, isstr := val.(string)
-				if !isstr || (isstr && value != strval) {
+				if !isstr || value != strval {
 					allowed = false
 					break
 				}

--- a/output/tcp/tcp.go
+++ b/output/tcp/tcp.go
@@ -61,7 +61,7 @@ func (s *TCPServer) accept(c net.Conn) {
 					break
 				}
 				strval, isstr := val.(string)
-				if !isstr || (isstr && value != strval) {
+				if !isstr || value != strval {
 					allowed = false
 					break
 				}

--- a/output/websocket/websocket.go
+++ b/output/websocket/websocket.go
@@ -83,7 +83,7 @@ func (ws *WebSocketServer) wslogsHandler(w *websocket.Conn) {
 					break
 				}
 				strval, isstr := val.(string)
-				if !isstr || (isstr && value != strval) {
+				if !isstr || value != strval {
 					allowed = false
 					break
 				}


### PR DESCRIPTION
This is a proposed enhancement to provide basic, low-cost routing and filtering capabilities to logzoom. 

It doesn't do anything terribly special, it just adds a new config value to output plugins (currently es and s3) called if_has_field.  If the config value is set, then it checks each inbound event for the presence of that Field before allowing it to proceed.  It is very low cost, because it is only checking the field name, which is already unpacked into a hash-map.  It doesn't need to construct any values from interface{}. 

The use case for us is that we want to use logzoom to send business events,  debug/error logs, and application profiler events through the same place and have them "routed" based on their type.  In many cases a message can be destined for 1, or 2 of the 3 destinations, which is why checking for fields is pretty much the only simple way to accomplish this. 

I am certainly open to ideas as to better ways to accomplish this architecturally, or alternate ways to implement this in code.  

Thanks for making logzoom!
