### PR TITLE
Make Lumberjack SSL optional

### DIFF
--- a/input/filebeat/lumberjack.go
+++ b/input/filebeat/lumberjack.go
@@ -11,10 +11,10 @@ import (
 )
 
 type Config struct {
-	Host   string `yaml:"host"`
-	SSLCrt string `yaml:"ssl_crt"`
-	SSLKey string `yaml:"ssl_key"`
-	SampleSize *int `yaml:"sample_size,omitempty"`
+	Host       string `yaml:"host"`
+	SSLCrt     string `yaml:"ssl_crt,omitempty"`
+	SSLKey     string `yaml:"ssl_key,omitempty"`
+	SampleSize *int   `yaml:"sample_size,omitempty"`
 }
 
 type LJServer struct {
@@ -25,7 +25,7 @@ type LJServer struct {
 }
 
 func New() input.Input {
-        return &LJServer{term: make(chan bool, 1)}
+	return &LJServer{term: make(chan bool, 1)}
 }
 
 // lumberConn handles an incoming connection from a lumberjack client
@@ -55,9 +55,26 @@ func (lj *LJServer) Init(name string, config yaml.MapSlice, r input.Receiver) er
 }
 
 func (lj *LJServer) Start() error {
-	cert, err := tls.LoadX509KeyPair(lj.Config.SSLCrt, lj.Config.SSLKey)
-	if err != nil {
-		return fmt.Errorf("Error loading keys: %v", err)
+	var ln net.Listener
+
+	if lj.Config.SSLCrt != "" {
+		cert, err := tls.LoadX509KeyPair(lj.Config.SSLCrt, lj.Config.SSLKey)
+		if err != nil {
+			return fmt.Errorf("Error loading keys: %v", err)
+		}
+
+		conn, err := net.Listen("tcp", lj.Config.Host)
+		if err != nil {
+			return fmt.Errorf("Listener failed: %v", err)
+		}
+		config := tls.Config{Certificates: []tls.Certificate{cert}}
+		ln = tls.NewListener(conn, &config)
+	} else {
+		var err error
+		ln, err = net.Listen("tcp", lj.Config.Host)
+		if err != nil {
+			return fmt.Errorf("TCP Listener failed: %v", err)
+		}
 	}
 
 	if lj.Config.SampleSize == nil {
@@ -65,15 +82,6 @@ func (lj *LJServer) Start() error {
 		lj.Config.SampleSize = &i
 	}
 	log.Printf("[%s] Setting Sample Size to %d%%", lj.name, *lj.Config.SampleSize)
-
-	conn, err := net.Listen("tcp", lj.Config.Host)
-	if err != nil {
-		return fmt.Errorf("Listener failed: %v", err)
-	}
-
-	config := tls.Config{Certificates: []tls.Certificate{cert}}
-
-	ln := tls.NewListener(conn, &config)
 
 	log.Printf("[%s] Started Lumberjack Instance", lj.name)
 	for {


### PR DESCRIPTION
Filebeat can run with SSL disabled.  As our use case is filebeat->logzoom->s3 on the same machine it doesn't make sense to have the SSL overhead.

This is basically #9 again but without merge conflicts.